### PR TITLE
Correcting RHEL8 template sftp path + Add RHEL9 template

### DIFF
--- a/defaults/main/redhat9.yml
+++ b/defaults/main/redhat9.yml
@@ -1,5 +1,5 @@
 ---
-sshd_config_default_redhat_ootpa:
+sshd_config_default_redhat_plow:
   Protocol: 2
   PermitRootLogin: "no"
   PubkeyAuthentication: "yes"


### PR DESCRIPTION
Correcting RHEL8 template sftp path + Add RHEL9 template

## Description
RHEL8 template provides a wrong path to sftp-server binary on RHEL8 ( /usr/lib instead of /usr/libexec )
Adding RHEL9 template

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
